### PR TITLE
fix: typo in favorites download

### DIFF
--- a/src/routes/(admin my)/my/favorites/+page.svelte
+++ b/src/routes/(admin my)/my/favorites/+page.svelte
@@ -40,7 +40,7 @@
 			title: a.title ? a.title : '',
 			speakers: a.speakers.map((s) => `${s.firstName} ${s.lastName}`).join(';'),
 			priCategory: a.priCategory ? a.priCategory : '',
-			sessionLink: `https://thatconference.com/activites/${a.id}/`,
+			sessionLink: `https://thatconference.com/activities/${a.id}/`,
 			sessionType: a.type
 		}));
 


### PR DESCRIPTION
Fix typo in /activities url for my favorites download