### PR TITLE
Refactor/sourcemaps and env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.0.3",
+	"version": "5.0.4",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -1,11 +1,13 @@
 import * as Sentry from '@sentry/sveltekit';
+import { env } from '$env/dynamic/public';
 
 Sentry.init({
 	dsn: 'https://857800ed593d481bb0da2843516d7845@o235190.ingest.sentry.io/4504617287417856',
 	tracesSampleRate: 1,
 	replaysSessionSampleRate: 0.1,
 	replaysOnErrorSampleRate: 1,
-	integrations: [new Sentry.Replay()]
+	integrations: [new Sentry.Replay()],
+	environment: env.PUBLIC_VERCEL_ENV
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,9 +1,11 @@
 import { sequence } from '@sveltejs/kit/hooks';
+import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
 	dsn: 'https://857800ed593d481bb0da2843516d7845@o235190.ingest.sentry.io/4504617287417856',
-	tracesSampleRate: 1
+	tracesSampleRate: 1,
+	environment: env.PUBLIC_VERCEL_ENV
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/lib/config.public.js
+++ b/src/lib/config.public.js
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/public';
+import { version } from '$app/environment';
 
 function configMissing(configKey) {
 	const message = `Missing required public environment varable: ${configKey}`;
@@ -7,8 +8,8 @@ function configMissing(configKey) {
 
 export default {
 	hostURL: env.PUBLIC_HOST_URL || 'https://thatconference.com',
-	nodeEnv: env.NODE_ENV,
-	version: '5.0.0',
+	nodeEnv: env.PUBLIC_VERCEL_ENV,
+	version: version ?? '0.0.0.0',
 	eventId: 'YWavA70szR8rxSwrLJaL',
 	eventSlug: 'thatus/daily',
 	api: {
@@ -47,7 +48,7 @@ export const securityConfig = () => {
 
 export const logging = {
 	dsn: 'https://857800ed593d481bb0da2843516d7845@o235190.ingest.sentry.io/4504617287417856',
-	environment: env.NODE_ENV
+	environment: env.PUBLIC_VERCEL_ENV
 };
 
 export const debug = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,28 +7,26 @@ const config = ({ mode }) => {
 	process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
 
 	const sentryConfig = {
-		sourceMapsUploadOptions: {
-			url: 'https://sentry.io',
-			authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
-			org: 'that-conference',
-			project: 'thatconference-com',
-			release: pkg.version,
-			setCommits: {
-				auto: true,
-				ignoreMissing: true
-			},
-			sourceMaps: {
-				assets: ['./.svelte-kit/output'],
-				ignore: ['node_modules'],
-				validate: true
-			},
-			deploy: {
-				env: 'production'
-			},
-			debug: false,
-			dryRun: false,
-			cleanArtifacts: true
-		}
+		url: 'https://sentry.io',
+		authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
+		org: 'that-conference',
+		project: 'thatconference-com',
+		release: pkg.version,
+		setCommits: {
+			auto: true,
+			ignoreMissing: true
+		},
+		sourceMaps: {
+			assets: ['./.svelte-kit/output'],
+			ignore: ['node_modules'],
+			validate: true
+		},
+		deploy: {
+			env: 'production'
+		},
+		debug: false,
+		dryRun: false,
+		cleanArtifacts: true
 	};
 
 	return defineConfig({

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,26 +7,28 @@ const config = ({ mode }) => {
 	process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
 
 	const sentryConfig = {
-		url: 'https://sentry.io',
-		authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
-		org: 'that-conference',
-		project: 'thatconference-com',
-		release: pkg.version,
-		deploy: {
-			env: 'production'
-		},
-		setCommits: {
-			auto: true,
-			ignoreMissing: true
-		},
-		sourceMaps: {
-			include: ['./.svelte-kit/output'],
-			ignore: ['node_modules'],
-			validate: true
-		},
-		debug: false,
-		dryRun: false,
-		cleanArtifacts: true
+		sourceMapsUploadOptions: {
+			url: 'https://sentry.io',
+			authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
+			org: 'that-conference',
+			project: 'thatconference-com',
+			release: pkg.version,
+			setCommits: {
+				auto: true,
+				ignoreMissing: true
+			},
+			sourceMaps: {
+				assets: ['./.svelte-kit/output'],
+				ignore: ['node_modules'],
+				validate: true
+			},
+			deploy: {
+				env: 'production'
+			},
+			debug: false,
+			dryRun: false,
+			cleanArtifacts: true
+		}
 	};
 
 	return defineConfig({
@@ -41,3 +43,6 @@ const config = ({ mode }) => {
 };
 
 export default config;
+
+// Sentry vite plugin reference:
+// https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/259018857f1fd58b29a8fa92fa573953a9c30fca/packages/vite-plugin


### PR DESCRIPTION
## v5.0.4

refactor use of `NODE_ENV`, it's not exposed by Sveltekit. We're using value `PUBLIC_VERCEL_ENV`
refactor source maps setting for sentry's vite plugin settings

reference to sentry vite plugin options:
https://www.npmjs.com/package/@sentry/vite-plugin
~~https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/259018857f1fd58b29a8fa92fa573953a9c30fca/packages/vite-plugin~~