### PR TITLE
promote Next/feature to production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "thatconference.com",
-	"version": "5.0.0",
+	"version": "5.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "thatconference.com",
-			"version": "5.0.0",
+			"version": "5.0.5",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@sentry/sveltekit": "^7.69.0"
@@ -18,8 +18,8 @@
 				"@fortawesome/free-regular-svg-icons": "^6.4.2",
 				"@fullhuman/postcss-purgecss": "^5.0.0",
 				"@playwright/test": "^1.37.1",
-				"@sentry/svelte": "^7.69.0",
-				"@sentry/tracing": "^7.69.0",
+				"@sentry/svelte": "^7.73.0",
+				"@sentry/tracing": "^7.73.0",
 				"@stripe/stripe-js": "^2.1.5",
 				"@sveltejs/adapter-auto": "2.1.0",
 				"@sveltejs/kit": "1.25.0",
@@ -1452,15 +1452,67 @@
 			}
 		},
 		"node_modules/@sentry/browser": {
-			"version": "7.69.0",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.69.0.tgz",
-			"integrity": "sha512-5ls+zu2PrMhHCIIhclKQsWX5u6WH0Ez5/GgrCMZTtZ1d70ukGSRUvpZG9qGf5Cw1ezS1LY+1HCc3whf8x8lyPw==",
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.73.0.tgz",
+			"integrity": "sha512-e301hUixcJ5+HNKCJwajFF5smF4opXEFSclyWsJuFNufv5J/1C1SDhbwG2JjBt5zzdSoKWJKT1ewR6vpICyoDw==",
+			"dev": true,
 			"dependencies": {
-				"@sentry-internal/tracing": "7.69.0",
-				"@sentry/core": "7.69.0",
-				"@sentry/replay": "7.69.0",
-				"@sentry/types": "7.69.0",
-				"@sentry/utils": "7.69.0",
+				"@sentry-internal/tracing": "7.73.0",
+				"@sentry/core": "7.73.0",
+				"@sentry/replay": "7.73.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/browser/node_modules/@sentry-internal/tracing": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.73.0.tgz",
+			"integrity": "sha512-ig3WL/Nqp8nRQ52P205NaypGKNfIl/G+cIqge9xPW6zfRb5kJdM1YParw9GSJ1SPjEZBkBORGAML0on5H2FILw==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/core": "7.73.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/browser/node_modules/@sentry/core": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+			"integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/browser/node_modules/@sentry/types": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+			"integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/browser/node_modules/@sentry/utils": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+			"integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/types": "7.73.0",
 				"tslib": "^2.4.1 || ^1.9.3"
 			},
 			"engines": {
@@ -1569,26 +1621,64 @@
 			}
 		},
 		"node_modules/@sentry/replay": {
-			"version": "7.69.0",
-			"resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.69.0.tgz",
-			"integrity": "sha512-oUqWyBPFUgShdVvgJtV65EQH9pVDmoYVQMOu59JI6FHVeL3ald7R5Mvz6GaNLXsirvvhp0yAkcAd2hc5Xi6hDw==",
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.73.0.tgz",
+			"integrity": "sha512-a8IC9SowBisLYD2IdLkXzx7gN4iVwHDJhQvLp2B8ARs1PyPjJ7gCxSMHeGrYp94V0gOXtorNYkrxvuX8ayPROA==",
+			"dev": true,
 			"dependencies": {
-				"@sentry/core": "7.69.0",
-				"@sentry/types": "7.69.0",
-				"@sentry/utils": "7.69.0"
+				"@sentry/core": "7.73.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/@sentry/svelte": {
-			"version": "7.69.0",
-			"resolved": "https://registry.npmjs.org/@sentry/svelte/-/svelte-7.69.0.tgz",
-			"integrity": "sha512-86dQMJ+iYMZHEv3m3OGK6M6+Pq2C0/udeWIw5HLUil8SvJ0mKqAw8lzHcH9P7Vuhcdqn7N2fZfoUCyDIm7wRqA==",
+		"node_modules/@sentry/replay/node_modules/@sentry/core": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+			"integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+			"dev": true,
 			"dependencies": {
-				"@sentry/browser": "7.69.0",
-				"@sentry/types": "7.69.0",
-				"@sentry/utils": "7.69.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/replay/node_modules/@sentry/types": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+			"integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/replay/node_modules/@sentry/utils": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+			"integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/types": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/svelte": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/svelte/-/svelte-7.73.0.tgz",
+			"integrity": "sha512-wori/ZeOxiYb8yWLNeFhuAiPtvDkmDMX7Cxlmg6yxc/L4Awjx5zFGtsQLW/LiEUHOTdIpJqWXhkFm6u4EMRafw==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/browser": "7.73.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
 				"magic-string": "^0.30.0",
 				"tslib": "^2.4.1 || ^1.9.3"
 			},
@@ -1597,6 +1687,28 @@
 			},
 			"peerDependencies": {
 				"svelte": "3.x || 4.x"
+			}
+		},
+		"node_modules/@sentry/svelte/node_modules/@sentry/types": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+			"integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/svelte/node_modules/@sentry/utils": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+			"integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+			"dev": true,
+			"dependencies": {
+				"@sentry/types": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/sveltekit": {
@@ -1622,12 +1734,106 @@
 				"@sveltejs/kit": "1.x"
 			}
 		},
-		"node_modules/@sentry/tracing": {
+		"node_modules/@sentry/sveltekit/node_modules/@sentry/browser": {
 			"version": "7.69.0",
-			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.69.0.tgz",
-			"integrity": "sha512-nhwJXyLU2KT6ci3YRUCkpFQH7RL9lpEuVDHqaJ9xLql766FJ7A7jKtRGSaefgRzJvvdKHUVboIjZnSvqIu8gWw==",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.69.0.tgz",
+			"integrity": "sha512-5ls+zu2PrMhHCIIhclKQsWX5u6WH0Ez5/GgrCMZTtZ1d70ukGSRUvpZG9qGf5Cw1ezS1LY+1HCc3whf8x8lyPw==",
 			"dependencies": {
-				"@sentry-internal/tracing": "7.69.0"
+				"@sentry-internal/tracing": "7.69.0",
+				"@sentry/core": "7.69.0",
+				"@sentry/replay": "7.69.0",
+				"@sentry/types": "7.69.0",
+				"@sentry/utils": "7.69.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/sveltekit/node_modules/@sentry/replay": {
+			"version": "7.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.69.0.tgz",
+			"integrity": "sha512-oUqWyBPFUgShdVvgJtV65EQH9pVDmoYVQMOu59JI6FHVeL3ald7R5Mvz6GaNLXsirvvhp0yAkcAd2hc5Xi6hDw==",
+			"dependencies": {
+				"@sentry/core": "7.69.0",
+				"@sentry/types": "7.69.0",
+				"@sentry/utils": "7.69.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@sentry/sveltekit/node_modules/@sentry/svelte": {
+			"version": "7.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/svelte/-/svelte-7.69.0.tgz",
+			"integrity": "sha512-86dQMJ+iYMZHEv3m3OGK6M6+Pq2C0/udeWIw5HLUil8SvJ0mKqAw8lzHcH9P7Vuhcdqn7N2fZfoUCyDIm7wRqA==",
+			"dependencies": {
+				"@sentry/browser": "7.69.0",
+				"@sentry/types": "7.69.0",
+				"@sentry/utils": "7.69.0",
+				"magic-string": "^0.30.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"peerDependencies": {
+				"svelte": "3.x || 4.x"
+			}
+		},
+		"node_modules/@sentry/tracing": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.73.0.tgz",
+			"integrity": "sha512-LOQR6Hkc8ZoflCXWtMlxTbCBEwv0MSOr3vesnRsmlFG8TW1YUIneU+wKnVxToWAZ8fq+6ubclnuIUKHfqTk/Tg==",
+			"dependencies": {
+				"@sentry-internal/tracing": "7.73.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/tracing/node_modules/@sentry-internal/tracing": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.73.0.tgz",
+			"integrity": "sha512-ig3WL/Nqp8nRQ52P205NaypGKNfIl/G+cIqge9xPW6zfRb5kJdM1YParw9GSJ1SPjEZBkBORGAML0on5H2FILw==",
+			"dependencies": {
+				"@sentry/core": "7.73.0",
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/tracing/node_modules/@sentry/core": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+			"integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+			"dependencies": {
+				"@sentry/types": "7.73.0",
+				"@sentry/utils": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/tracing/node_modules/@sentry/types": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+			"integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sentry/tracing/node_modules/@sentry/utils": {
+			"version": "7.73.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+			"integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+			"dependencies": {
+				"@sentry/types": "7.73.0",
+				"tslib": "^2.4.1 || ^1.9.3"
 			},
 			"engines": {
 				"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.0.4",
+	"version": "5.0.5",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",
@@ -35,8 +35,8 @@
 		"@fortawesome/free-regular-svg-icons": "^6.4.2",
 		"@fullhuman/postcss-purgecss": "^5.0.0",
 		"@playwright/test": "^1.37.1",
-		"@sentry/svelte": "^7.69.0",
-		"@sentry/tracing": "^7.69.0",
+		"@sentry/svelte": "^7.73.0",
+		"@sentry/tracing": "^7.73.0",
 		"@stripe/stripe-js": "^2.1.5",
 		"@sveltejs/adapter-auto": "2.1.0",
 		"@sveltejs/kit": "1.25.0",

--- a/src/routes/(root)/call-for-speakers/[event]/[year]/+page.svelte
+++ b/src/routes/(root)/call-for-speakers/[event]/[year]/+page.svelte
@@ -13,6 +13,10 @@
 	import CTA from '../../_components/cta.svelte';
 
 	let { event } = data;
+	let showBecomeCounselorButt =
+		dayjs() >= dayjs(event.callForSpeakersOpenDate) &&
+		dayjs() <= dayjs(event.callForSpeakersCloseDate);
+
 	const metaTags = ((title = `${event?.name} Call For Counselors - THAT`) => ({
 		title,
 		tags: seoMetaTags({
@@ -20,7 +24,7 @@
 			description: 'Call For Counselors is now open',
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/call-for-counselors/${event.slug}`
+				url: `https://thatconference.com/call-for-speakers/${event.slug}`
 			}
 		})
 	}))();
@@ -67,12 +71,13 @@
 				</p>
 
 				<div class="flex justify-center space-x-4 pt-12">
-					<div class="flex-none">
-						<StandardLink href={`/activities/create/?event=${event.id}`}>
-							Become a Counselor
-						</StandardLink>
-					</div>
-
+					{#if showBecomeCounselorButt}
+						<div class="flex-none">
+							<StandardLink href={`/activities/create/?event=${event.id}`}>
+								Become a Counselor
+							</StandardLink>
+						</div>
+					{/if}
 					<div class="flex-none">
 						<StandardScroll href="#formatAndDates">View Formats and Dates</StandardScroll>
 					</div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,26 +7,30 @@ const config = ({ mode }) => {
 	process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
 
 	const sentryConfig = {
-		url: 'https://sentry.io',
-		authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
-		org: 'that-conference',
-		project: 'thatconference-com',
-		release: pkg.version,
-		setCommits: {
-			auto: true,
-			ignoreMissing: true
-		},
-		sourceMaps: {
-			assets: ['./.svelte-kit/output'],
-			ignore: ['node_modules'],
-			validate: true
-		},
-		deploy: {
-			env: 'production'
-		},
-		debug: false,
-		dryRun: false,
-		cleanArtifacts: true
+		sourceMapsUploadOptions: {
+			org: 'that-conference',
+			project: 'thatconference-com',
+			release: pkg.version,
+			authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
+			url: 'https://sentry.io',
+			cleanArtifacts: true,
+			rewrite: false,
+			// vite overrides NODE_ENV to production when running 'vite build'
+			uploadSourceMaps: process.env.PUBLIC_VERCEL_ENV === 'production',
+			deploy: {
+				env: 'production'
+			},
+			setCommits: {
+				auto: true,
+				ignoreMissing: true
+			},
+			sourceMaps: {
+				assets: ['./.svelte-kit/output'],
+				ignore: ['node_modules']
+			},
+			debug: false,
+			dryRun: false
+		}
 	};
 
 	return defineConfig({
@@ -44,3 +48,5 @@ export default config;
 
 // Sentry vite plugin reference:
 // https://github.com/getsentry/sentry-javascript-bundler-plugins/tree/259018857f1fd58b29a8fa92fa573953a9c30fca/packages/vite-plugin
+// sentry's vite plugin based on v0.61 per support ticket
+// https://www.npmjs.com/package/@sentry/vite-plugin/v/0.6.1


### PR DESCRIPTION
## v5.0.5

- hide become a counselor button on CFP page when not within open call dates. Button click causing site errors
  - e.g. https://feature.thatconference.com/call-for-speakers/wi/2024
- refactor sitemap uploads to sentry per support suggestions
- sentry package bumps