### PR TITLE
get leads working on thatconference.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.0.7",
+	"version": "5.0.8",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/lib/config.public.js
+++ b/src/lib/config.public.js
@@ -86,10 +86,12 @@ export const claimCodes = [
 export const events = {
 	next: {
 		tx: {
-			slug: 'tx/2024'
+			slug: 'tx/2024',
+			id: 'THATConferenceTexas2024'
 		},
 		wi: {
-			slug: 'wi/2024'
+			slug: 'wi/2024',
+			id: 'THATConferenceWisconsin2024'
 		}
 	}
 };

--- a/src/routes/(admin sponsor)/sponsor-admin/leads/+page.js
+++ b/src/routes/(admin sponsor)/sponsor-admin/leads/+page.js
@@ -1,7 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export async function load() {
-	const eventId = 'THATConferenceWisconsin2023';
-
-	throw redirect(301, `/sponsors/leads/${eventId}`);
-}

--- a/src/routes/(admin sponsor)/sponsor-admin/leads/+page.svelte
+++ b/src/routes/(admin sponsor)/sponsor-admin/leads/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { Standard as StandardLink } from '$elements/links';
+	import { events } from '$lib/config.public';
+</script>
+
+<div class="mx-auto max-w-md px-4 sm:px-6 lg:px-8">
+	<h1 class="mt-2 text-xl font-bold leading-6 text-thatBlue-800">THAT Contact Exchange</h1>
+	<p>Select an event</p>
+
+	<div class="mt-10 flex flex-col space-x-0 space-y-2 sm:flex-row sm:space-x-8 sm:space-y-0">
+		<StandardLink href="/sponsor-admin/leads/{events.next.wi.id}">Wisconsin</StandardLink>
+		<StandardLink href="/sponsor-admin/leads/{events.next.tx.id}">Texas</StandardLink>
+	</div>
+</div>

--- a/src/routes/(admin sponsor)/sponsor-admin/leads/[eventId]/+page.svelte
+++ b/src/routes/(admin sponsor)/sponsor-admin/leads/[eventId]/+page.svelte
@@ -64,7 +64,7 @@
 
 <Seo title={metaTags.title} tags={metaTags.tags} />
 
-<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+<div class="mx-auto max-w-md px-4 sm:px-6 lg:px-8">
 	<h1 class="mt-2 text-xl font-bold leading-6 text-thatBlue-800">THAT Contact Exchange</h1>
 	<div
 		class:opacity-100={showBanner}

--- a/src/routes/(root)/support/sponsors/forms/+page.svelte
+++ b/src/routes/(root)/support/sponsors/forms/+page.svelte
@@ -2,6 +2,7 @@
 	import { Standard as StandardLink } from '$elements/links';
 	import seoMetaTags from '$lib/seo/metaTags';
 	import Seo from '$components/Seo.svelte';
+	import { events } from '$lib/config.public';
 
 	import Header from '../../_components/_Header.svelte';
 
@@ -12,13 +13,13 @@
 			description: '',
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/support/sponsors/forms/`
+				url: `https://thatconference.com/support/sponsors/forms`
 			}
 		})
 	}))();
 
-	const txEventId = 'THATConferenceTexas2023';
-	const wiEventId = 'THATConferenceWisconsin2023';
+	const txEventId = events.next.tx.id;
+	const wiEventId = events.next.wi.id;
 </script>
 
 <Seo title={metaTags.title} tags={metaTags.tags} />
@@ -108,12 +109,12 @@
 						<h3>Important Event Links</h3>
 						<ul>
 							<li>
-								<a href={`/sponsors/leads/${txEventId}`} target="_blank" rel="noreferrer">
+								<a href={`/sponsor-admin/leads/${txEventId}`} target="_blank" rel="noreferrer">
 									Lead Generation
 								</a>
 							</li>
 							<li>
-								<a href="/sponsors/my-network" target="_blank">Lead Generation Results</a>
+								<a href="/sponsor-admin/my-network" target="_blank">Lead Generation Results</a>
 							</li>
 							<li>
 								<a href="/my/network/sponsors" target="_blank">Your Network</a>
@@ -237,8 +238,8 @@
 	<div class="prose prose-lg mt-4 text-gray-500">
 		<h3>Don't forget to:</h3>
 		<ul>
-			<li>Complete your ticket enrollment.</li>
 			<li>Book your stay.</li>
+			<li>Complete your ticket enrollment.</li>
 			<li>Update your THAT Conference profile.</li>
 			<li>Read the Sponsorship Handbook.</li>
 			<li>Review your company's spotlight page.</li>
@@ -248,6 +249,6 @@
 
 <style lang="postcss">
 	a:hover {
-		@apply text-thatBlue-700;
+		@apply hover:text-thatOrange-400;
 	}
 </style>


### PR DESCRIPTION
## v5.0.8

- refactor: leads for thatconference.com, correct referenced paths (/sponsor-admin)
- refactor: move hard-coded event ids to public config
- feat: add event selection at /leads root
- validated all links in /support/sponsor/forms fix some styling