### PR TITLE
fix: references of /events/{slug} to /{slug}

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.1.5",
+	"version": "5.1.6",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_components/activities/ActivityDetails.svelte
+++ b/src/_components/activities/ActivityDetails.svelte
@@ -369,7 +369,7 @@
 				class="flex flex-col items-center justify-center space-x-0 space-y-4 py-4 sm:flex-row sm:justify-start sm:space-x-8 sm:space-y-0">
 				{#if !isDailyActivity}
 					<div class="h-24 w-24">
-						<a href={`/events/${event.slug}`} class="h-full w-full">
+						<a href={`/${event.slug}`} class="h-full w-full">
 							<img class="lazyload" src={event.logo} alt="Event Logo" />
 						</a>
 					</div>

--- a/src/_components/cta/_HomePageCFP.svelte
+++ b/src/_components/cta/_HomePageCFP.svelte
@@ -10,7 +10,7 @@
 			class="absolute inset-0 -skew-y-6 transform bg-gradient-to-r from-that-orange to-that-red shadow-lg sm:-rotate-6 sm:skew-y-0 sm:rounded-3xl" />
 		<div class="relative bg-white px-4 py-6 shadow-lg sm:rounded-3xl sm:p-14">
 			<div class="mx-auto max-w-md">
-				<a href={`/events/${event.slug}`}>
+				<a href={`/${event.slug}`}>
 					<div
 						class="flex transform flex-col justify-center transition duration-500 ease-in-out hover:scale-105">
 						<img src={event.logo} class="h-24" alt="THAT Confernece Logo" />

--- a/src/_components/cta/_TicketsOnSale.svelte
+++ b/src/_components/cta/_TicketsOnSale.svelte
@@ -10,10 +10,10 @@
 			class="absolute inset-0 -skew-y-6 transform bg-gradient-to-r from-thatBlue-400 to-thatBlue-700 shadow-lg sm:-rotate-6 sm:skew-y-0 sm:rounded-3xl" />
 		<div class="relative bg-white px-4 py-6 shadow-lg sm:rounded-3xl sm:p-14">
 			<div class="mx-auto max-w-md">
-				<a href={`/events/${event.slug}`}>
+				<a href={`/${event.slug}`}>
 					<div
 						class="flex transform flex-col justify-center transition duration-500 ease-in-out hover:scale-105">
-						<img src={event.logo} class="h-24" alt="THAT Confernece Logo" />
+						<img src={event.logo} class="h-24" alt="THAT Conference Logo" />
 					</div>
 				</a>
 
@@ -34,7 +34,7 @@
 						</div>
 
 						<div class="space-y-2 text-center">
-							<div class="p-8 ">
+							<div class="p-8">
 								<p class="text-xl font-extrabold tracking-tight text-gray-500">
 									{dayjs(event.startDate).format('MMMM D, YYYY')} - {dayjs(event.endDate).format(
 										'MMMM D, YYYY'
@@ -53,9 +53,7 @@
 					<div class="pt-6 text-base font-bold leading-6 sm:text-lg sm:leading-7">
 						<p>Still need a ticket?</p>
 						<p>
-							<a
-								href={`/events/${event.slug}/tickets`}
-								class="text-that-red hover:text-thatRed-600">
+							<a href={`/${event.slug}/tickets`} class="text-that-red hover:text-thatRed-600">
 								Purchase Now &rarr;
 							</a>
 						</p>

--- a/src/_components/navigation/thatConference/NavHat.svelte
+++ b/src/_components/navigation/thatConference/NavHat.svelte
@@ -35,7 +35,7 @@
 
 				<span>-</span>
 
-				<a href={`/events/${event.slug}`}>
+				<a href={`/${event.slug}`}>
 					<div class="flex space-x-4 font-semibold uppercase tracking-wide antialiased">
 						<div class="flex items-center space-x-2 uppercase text-white">
 							<span>{venue.city}</span>

--- a/src/routes/(redirects)/family/+page.js
+++ b/src/routes/(redirects)/family/+page.js
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit';
 
 export async function load() {
-	throw redirect(302, `/events/wi/2023/schedule/?family=true`);
+	throw redirect(302, `/wi/2023/schedule/?family=true`);
 }

--- a/src/routes/(that conference online)/[event]/[date]/+page.svelte
+++ b/src/routes/(that conference online)/[event]/[date]/+page.svelte
@@ -35,7 +35,7 @@
 			description: `${event.description} at THAT`,
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/events/${eventSlug}`
+				url: `https://thatconference.com/${eventSlug}`
 			}
 		})
 	}))();

--- a/src/routes/(that conferences)/tx/[year]/+page.svelte
+++ b/src/routes/(that conferences)/tx/[year]/+page.svelte
@@ -33,7 +33,7 @@
 			description: `${event.description} at THAT`,
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/events/${event.slug}`
+				url: `https://thatconference.com/${event.slug}`
 			}
 		})
 	}))();

--- a/src/routes/(that conferences)/tx/[year]/_components/CamperTickets.svelte
+++ b/src/routes/(that conferences)/tx/[year]/_components/CamperTickets.svelte
@@ -266,7 +266,7 @@
 
 		<div class="mt-24 flex flex-col items-center">
 			<div class="animate-pulse">
-				<HighlightLink href={`/events/${event.slug}/tickets`}>
+				<HighlightLink href={`/${event.slug}/tickets`}>
 					<span class="text-xl font-bold uppercase tracking-wider"> View all ticket options </span>
 				</HighlightLink>
 			</div>

--- a/src/routes/(that conferences)/tx/[year]/schedule/+page.svelte
+++ b/src/routes/(that conferences)/tx/[year]/schedule/+page.svelte
@@ -16,7 +16,7 @@
 			description: 'That Conference Texas Speakers and Schedule',
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/events/tx/${event.slug}/schedule`
+				url: `https://thatconference.com/tx/${event.slug}/schedule`
 			}
 		})
 	}))();

--- a/src/routes/(that conferences)/tx/[year]/sponsors/+page.svelte
+++ b/src/routes/(that conferences)/tx/[year]/sponsors/+page.svelte
@@ -16,7 +16,7 @@
 			description: 'Thank you to those who support our great community every day.',
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/events/tx/${event.slug}/sponsors/`
+				url: `https://thatconference.com/tx/${event.slug}/sponsors/`
 			}
 		})
 	}))();

--- a/src/routes/(that conferences)/tx/[year]/tickets/+page.svelte
+++ b/src/routes/(that conferences)/tx/[year]/tickets/+page.svelte
@@ -21,7 +21,7 @@
 			description: 'Ticket Breakdown',
 			openGraph: {
 				type: 'website',
-				url: `https://thatconference.com/events/${event.slug}/tickets`
+				url: `https://thatconference.com/${event.slug}/tickets`
 			}
 		})
 	}))();

--- a/src/routes/(that conferences)/wi/[year]/_components/CamperTickets.svelte
+++ b/src/routes/(that conferences)/wi/[year]/_components/CamperTickets.svelte
@@ -275,7 +275,7 @@
 
 		<div class="mt-24 flex flex-col items-center">
 			<div class="animate-pulse">
-				<HighlightLink href={`/events/${event.slug}/tickets`}>
+				<HighlightLink href={`/${event.slug}/tickets`}>
 					<span class="text-xl font-bold uppercase tracking-wider"> View all ticket options </span>
 				</HighlightLink>
 			</div>


### PR DESCRIPTION
## v5.1.6

- fix references of `/events/{slug}` to `/{slug}` 

fixes #93 