### PR TITLE
refactor: /membership route to that.us in the short term

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.1.6",
+	"version": "5.1.7",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/routes/(redirects)/membership/+page.js
+++ b/src/routes/(redirects)/membership/+page.js
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export async function load() {
+	throw redirect(302, 'https://that.us/membership/');
+}

--- a/src/routes/(root)/_root/components/ctaMembership.svelte
+++ b/src/routes/(root)/_root/components/ctaMembership.svelte
@@ -13,7 +13,7 @@
 		<div class="mt-8 flex lg:mt-0 lg:flex-shrink-0">
 			<div class="inline-flex rounded-md shadow">
 				<a
-					href="/membership/"
+					href="/membership"
 					class="rounded-md border-2 border-transparent bg-thatOrange-400 px-8 py-3
             text-base font-medium leading-6 text-white shadow
             transition duration-150


### PR DESCRIPTION
## v5.1.7

- add temporary redirect for `/membership` to that.us

fixes #107 