### PR TITLE
Chore/sentry deny urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.1.9",
+	"version": "5.1.10",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -3,11 +3,13 @@ import { logging } from '$lib/config.public';
 
 Sentry.init({
 	dsn: logging.dsn,
+	attachStacktrace: true,
 	tracesSampleRate: 1,
 	replaysSessionSampleRate: 0.1,
 	replaysOnErrorSampleRate: 1,
 	integrations: [new Sentry.Replay()],
-	environment: logging.environment
+	environment: logging.environment,
+	denyUrls: logging.denyUrls
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -15,8 +15,10 @@ const { clientSecret, secret } = privateConfig();
 
 Sentry.init({
 	dsn: logging.dsn,
+	attachStacktrace: true,
 	environment: logging.environment,
-	tracesSampleRate: 1
+	tracesSampleRate: 1,
+	denyUrls: logging.denyUrls
 });
 
 const loginRedirectPaths = ['/my', '/sponsor-admin', '/admin', '/speakers'];

--- a/src/lib/config.public.js
+++ b/src/lib/config.public.js
@@ -48,7 +48,15 @@ export const securityConfig = () => {
 
 export const logging = {
 	dsn: 'https://857800ed593d481bb0da2843516d7845@o235190.ingest.sentry.io/4504617287417856',
-	environment: env.PUBLIC_VERCEL_ENV
+	environment: env.PUBLIC_VERCEL_ENV,
+	denyUrls: [
+		'/cdn-cgi/zaraz/',
+		'https://js.zi-scripts.com/', // zoom info
+		/^chrome:\/\//i,
+		/^https?:\/\/(?:\w+\.)?cloudflareinsights\.com\//,
+		/^https?:\/\/(?:\w+\.)?gstatic\.com\//,
+		'bpm:///conversations-embed'
+	]
 };
 
 export const debug = {


### PR DESCRIPTION
## v5.1.10

Add two parameters to sentry init: `attachStacktrace: true` and `denyUrls: []`

`attachStacktrace` ([ref](https://docs.sentry.io/platforms/javascript/configuration/options/#attach-stacktrace)) automatically attaches stack traces to all messages, not only exceptions.  
`denyUrls` ([ref](https://docs.sentry.io/platforms/javascript/configuration/options/#deny-urls)) sets an array of urls matches to ignore. Errors originating from these urls, e.g. zaraz, will not be logged in Sentry, cleaning up the noise. 