### PR TITLE
fix: issue where partner contact is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "thatconference.com",
-	"version": "5.1.14",
+	"version": "5.1.15",
 	"description": "THATConference.com website",
 	"main": "index.js",
 	"type": "module",

--- a/src/routes/(admin my)/my/network/sponsors/+page.svelte
+++ b/src/routes/(admin my)/my/network/sponsors/+page.svelte
@@ -35,25 +35,36 @@
 											<img class="h-12 w-12" src={c.partner.companyLogo} alt="" />
 										</div>
 										<div class="min-w-0 flex-1 px-4 md:grid md:grid-cols-2 md:gap-4">
-											<div>
-												<p class="truncate text-sm font-medium text-thatBlue-800">
-													{c.partnerContact.firstName}
-													{c.partnerContact.lastName}
-												</p>
-												<p class="mt-2 flex items-center text-sm text-gray-500">
-													<svg
-														class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400"
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 20 20"
-														fill="currentColor"
-														aria-hidden="true">
-														<path
-															d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-														<path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-													</svg>
-													<span class="truncate">{c.partnerContact.email}</span>
-												</p>
-											</div>
+											{#if c.partnerContact}
+												<div>
+													<p class="truncate text-sm font-medium text-thatBlue-800">
+														{c.partnerContact.firstName}
+														{c.partnerContact.lastName}
+													</p>
+													<p class="mt-2 flex items-center text-sm text-gray-500">
+														<svg
+															class="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400"
+															xmlns="http://www.w3.org/2000/svg"
+															viewBox="0 0 20 20"
+															fill="currentColor"
+															aria-hidden="true">
+															<path
+																d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+															<path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+														</svg>
+														<span class="truncate">{c.partnerContact.email}</span>
+													</p>
+												</div>
+											{:else}
+												<div>
+													<p class="truncate text-sm font-medium text-thatBlue-800">
+														{c.partner.companyName}
+													</p>
+													<p class="mt-2 flex items-center text-sm text-gray-500">
+														Connection created by you
+													</p>
+												</div>
+											{/if}
 											<div class="hidden md:block">
 												<div>
 													<p class="text-sm text-gray-900">


### PR DESCRIPTION
## v5.1.15

fix the issue in my network sponsors list where partner contact is null.
Partner contact is null when the connection is created by the member. 

fixes: https://that-conference.sentry.io/issues/4636978875/?alert_rule_id=14721499&alert_type=issue&environment=production&notification_uuid=720cdd00-1ea8-4539-88bd-df0325997dc3&project=4504617287417856&referrer=slack