### PR TITLE
fix - cancelled keynotes

### DIFF
--- a/src/_components/activities/List.svelte
+++ b/src/_components/activities/List.svelte
@@ -149,7 +149,9 @@
 	function isKeynote(activity) {
 		let results = false;
 
-		if (activity.type === 'KEYNOTE' || activity.type === 'PANEL') results = true;
+		if (activity.status === 'ACCEPTED') {
+			if (activity.type === 'KEYNOTE' || activity.type === 'PANEL') results = true;
+		}
 
 		return results;
 	}


### PR DESCRIPTION
looks at the session status before adding keynotes to the grid
